### PR TITLE
docs: add module docstrings

### DIFF
--- a/src/grader_helper/__init__.py
+++ b/src/grader_helper/__init__.py
@@ -1,5 +1,15 @@
-
 #!/usr/bin/env python
+"""Public package interface for :mod:`grader_helper`.
+
+This module re-exports the core data models and convenience functions used
+throughout the package.  The intent is to provide a single import location for
+common types such as :class:`Course`, :class:`CourseWork`, and helpers for
+reading and writing YAML representations.
+
+Exports ``Course``, ``CourseWork``, ``CourseWorkType``, ``GradeFile``,
+``HandBook``, ``Calendar``, ``write_item_to_yaml``, ``import_item_from_yaml``,
+and ``guess_model_type``.
+"""
 
 from grader_helper.models import (
     Course,

--- a/src/grader_helper/exporting/__init__.py
+++ b/src/grader_helper/exporting/__init__.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+"""Tools for exporting grading data.
+
+This subpackage currently exposes :func:`write_item_to_yaml` for serialising
+model instances to YAML files.
+"""
 
 from .write_item_to_yaml import write_item_to_yaml
 

--- a/src/grader_helper/helpers/__init__.py
+++ b/src/grader_helper/helpers/__init__.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+"""Helper utilities for :mod:`grader_helper`.
+
+Currently this module exposes :func:`guess_model_type`, which infers the model
+class from a YAML mapping.
+"""
 
 from .guess_model_type import guess_model_type
 

--- a/src/grader_helper/ingesting/__init__.py
+++ b/src/grader_helper/ingesting/__init__.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-""" This is the init file for the ingesting module."""
+"""Utilities for importing grading data from various sources.
+
+The ingesting package gathers functions for reading data files such as grader
+lists, Brightspace classlists, completed grader spreadsheets, and YAML
+descriptions of models.  It exports ``load_graders``,
+``import_brightspace_classlist``, ``ingest_completed_graderfiles``, and
+``import_item_from_yaml``.
+"""
 
 from .load_graders import load_graders
 from .import_brightspace_classlist import import_brightspace_classlist

--- a/src/grader_helper/ingesting/import_brightspace_classlist.py
+++ b/src/grader_helper/ingesting/import_brightspace_classlist.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""Import Brightspace classlist CSV files.
+
+Provides :func:`import_brightspace_classlist` for reading a Brightspace export
+and returning a tidy :class:`pandas.DataFrame` containing student identifiers and
+assignment grades.
+"""
 
 import pandas as pd
 import pathlib as pl

--- a/src/grader_helper/ingesting/import_item_from_yaml.py
+++ b/src/grader_helper/ingesting/import_item_from_yaml.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
+"""Import model instances from YAML definitions.
 
+Exports :func:`import_item_from_yaml`, which reads a YAML file and returns a
+``Course`` or ``CourseWork`` instance based on the file's contents.
+"""
 
 from grader_helper.models import Course, CourseWork
 from grader_helper.dependencies import ym, pl

--- a/src/grader_helper/ingesting/ingest_completed_graderfiles.py
+++ b/src/grader_helper/ingesting/ingest_completed_graderfiles.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""Combine completed grader files into a single DataFrame.
+
+The :func:`ingest_completed_graderfiles` function reads individual grader
+spreadsheets (CSV or Excel) and concatenates them, optionally writing the merged
+result back to disk.
+"""
 
 from ..dependencies import pd, pl
 

--- a/src/grader_helper/ingesting/load_graders.py
+++ b/src/grader_helper/ingesting/load_graders.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""Load a plain text list of graders.
+
+Exposes :func:`load_graders`, which reads newline-delimited grader names from a
+file and returns them as a list of strings.
+"""
 
 from typing import List
 import pathlib as pl

--- a/src/grader_helper/models/__init__.py
+++ b/src/grader_helper/models/__init__.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
+"""Re-export the core data models used by :mod:`grader_helper`.
 
+This module gathers convenient aliases for working with courses, coursework and
+related document types.  The primary exports include ``Course``, ``CourseWork``,
+``CourseWorkType``, ``GradeFile``, ``HandBook``, ``ClassList``, ``FileType`` and
+``Calendar``.
+"""
 
 from .Documents import (
     GradeFile, HandBook, ClassList, FileType, Calendar, )


### PR DESCRIPTION
## Summary
- add package docstring summarizing core exports
- document exporting, helper, ingesting, and model subpackages
- clarify purpose of ingestion helpers like `import_brightspace_classlist`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ruamel')*

------
https://chatgpt.com/codex/tasks/task_e_6895003864208333aa1d6ebe5fb77161